### PR TITLE
restrictions for number of players

### DIFF
--- a/src/pages/Game/Lobby/index.tsx
+++ b/src/pages/Game/Lobby/index.tsx
@@ -22,6 +22,11 @@ export const Lobby: React.FC = () => {
 
     if (!game || !peerId) return null;
 
+    const players = Object.values(game.players);
+
+    const canStart =
+        players.length >= 2 && players.every((player) => player.ready);
+
     return (
         <>
             <h2 className="text-center">Game room {game.id}</h2>
@@ -54,15 +59,24 @@ export const Lobby: React.FC = () => {
                             label="Ready"
                             size="small"
                             onClick={() => togglePlayerReady(player.id)}
-                        />{' '}
+                        />
                         <Button
                             label="Start Game"
                             size="small"
-                            disabled={Object.keys(game.players).some(
-                                (pk) => !game.players[pk].ready
-                            )}
+                            disabled={!canStart}
                             onClick={() => startGame()}
                         />
+                        {!canStart && players.length < 2 && (
+                            <div className="text-sm">
+                                At least 2 players are required to start
+                            </div>
+                        )}
+
+                        {!canStart && players.length >= 2 && (
+                            <div className="text-sm">
+                                Waiting for all players to be ready
+                            </div>
+                        )}
                     </div>
                 )}
             </div>


### PR DESCRIPTION
Restricts game start in Lobby to ensure a valid minimum player state.

## Changes
- Start Game button is disabled if:
  - less than 2 players are present
  - not all players are ready
- Added feedback messages:
  - "At least 2 players are required to start"
  - "Waiting for all players to be ready"
- Refactored lobby logic to compute `canStart` from a single source of truth

## Why
Previously a game could start with:
- only one player
- or players not ready