### PR TITLE
Back to yarn 1

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,5 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
-  },
-  "packageManager": "yarn@4.14.1+sha512.64df448055b2d37ba269d7db535a469b8da93f8ef1140c25fd7a83c00a8fbaacb214ca0e02553b92a2c54cef78bb67d0b4817fab02001df0e24fac0faccc3b42"
+  } 
 }

--- a/src/pages/Game/index.tsx
+++ b/src/pages/Game/index.tsx
@@ -5,6 +5,8 @@ import { initGame, useGame } from '../../state/game';
 import { Lobby } from './Lobby';
 import { End } from './End';
 import { Running } from './Running';
+import { startHeartbeat } from '../../utils/heartbeat';
+import { startPresenceCheck } from '../../state/presence';
 
 export interface GamePageProps {
     id?: string;
@@ -21,6 +23,14 @@ export const GamePage: React.FC<GamePageProps> = ({ id, init = true }) => {
             initGame(i ?? '');
         }
     }, [i, init]);
+
+    useEffect(() => {
+        startHeartbeat();
+    }, []);
+
+    useEffect(() => {
+        startPresenceCheck();
+    }, []);
 
     if (!game) return null;
 

--- a/src/state/game.ts
+++ b/src/state/game.ts
@@ -45,6 +45,8 @@ export const setTimeEstimate = createEvent<{
     estimate: number;
 }>();
 
+export const heartbeat = createEvent<{ playerId: string }>(); //this player is still alive
+
 const changePlayerTurn = (
     game: Game | null,
     playerId: string,
@@ -135,6 +137,17 @@ gameDS
                 ...playersTurn[pk],
             };
         });
+
+        return { ...game };
+    })
+    .on('heartbeat', heartbeat, (game, { playerId }) => {
+        if (!game) return null;
+
+        const player = game.players[playerId];
+
+        if (player) {
+            player.lastSeen = Date.now();
+        }
 
         return { ...game };
     });

--- a/src/state/heartbeat.ts
+++ b/src/state/heartbeat.ts
@@ -1,0 +1,15 @@
+import { createEvent, sample } from 'effector';
+import { $player } from './player';
+import { heartbeat } from './game';
+
+export const tick = createEvent<void>();
+
+sample({
+    clock: tick,
+    source: $player,
+    filter: Boolean,
+    fn: (player) => ({
+        playerId: player.id,
+    }),
+    target: heartbeat,
+});

--- a/src/state/presence.ts
+++ b/src/state/presence.ts
@@ -1,0 +1,29 @@
+import { $game, updateGame } from './game';
+
+const TIMEOUT = 8000;
+
+export const startPresenceCheck = () => {
+    setInterval(() => {
+        const game = $game.getState();
+        if (!game) return;
+
+        const now = Date.now();
+
+        let changed = false;
+
+        const newPlayers = { ...game.players };
+
+        for (const id of Object.keys(newPlayers)) {
+            const player = newPlayers[id];
+
+            if (now - (player.lastSeen ?? 0) > TIMEOUT) {
+                delete newPlayers[id];
+                changed = true;
+            }
+        }
+
+        if (changed) {
+            updateGame({ ...game, players: newPlayers });
+        }
+    }, 3000);
+};

--- a/src/state/types.ts
+++ b/src/state/types.ts
@@ -11,6 +11,7 @@ export interface Player {
     id: string;
     name: string;
     ready: boolean;
+    lastSeen?: number;
 }
 
 export interface GameTurn {

--- a/src/utils/heartbeat.ts
+++ b/src/utils/heartbeat.ts
@@ -1,0 +1,7 @@
+import { tick } from '../state/heartbeat';
+
+export const startHeartbeat = () => {
+    setInterval(() => {
+        tick();
+    }, 3000);
+};


### PR DESCRIPTION
Removes the packageManager field introduced with Yarn 4/Corepack.

The current deployment environment still uses Yarn 1, which causes yarn install to fail during CI/CD.

This restores compatibility with the existing deployment pipeline.